### PR TITLE
Reading a source class from a jar file

### DIFF
--- a/controller/src/main/java/cern/jarrace/controller/io/JarReader.java
+++ b/controller/src/main/java/cern/jarrace/controller/io/JarReader.java
@@ -1,0 +1,80 @@
+/*
+ * © Copyright 2016 CERN. This software is distributed under the terms of the Apache License Version 2.0, copied
+ * verbatim in the file “COPYING”. In applying this licence, CERN does not waive the privileges and immunities granted
+ * to it by virtue of its status as an Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+package cern.jarrace.controller.io;
+
+import cern.jarrace.commons.domain.AgentContainer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+
+/**
+ * Reads entries as strings from inside a jar file.
+ */
+public class JarReader implements AutoCloseable {
+
+    private final JarFile jarFile;
+
+    /**
+     * Creates a JarReader from a given {@link JarFile}.
+     *
+     * @param jarFile The jar to read from.
+     */
+    JarReader(JarFile jarFile) {
+        this.jarFile = jarFile;
+    }
+
+    @Override
+    public void close() throws IOException {
+        jarFile.close();
+    }
+
+    /**
+     * Reads the content of the given entry file in the jar of this JarReader, if it exists.
+     *
+     * @param entryName The name of the entry inside the jar file. Example: <code>cern.test.Class.java</code>
+     * @return A String with the contents of the file.
+     * @throws IOException If the entry could not be read.
+     */
+    public String readEntry(String entryName) throws IOException {
+        ZipEntry entry = jarFile.getEntry(entryName);
+        if (entry == null) {
+            throw new NoSuchElementException(String.format("Entry '%s' could not be found in jar %s", entryName, jarFile));
+        }
+        try (InputStream input = jarFile.getInputStream(entry);
+             InputStreamReader inputReader = new InputStreamReader(input);
+             BufferedReader reader = new BufferedReader(inputReader)) {
+            return reader.lines().collect(Collectors.joining("\n"));
+        }
+    }
+
+    /**
+     * Creates a {@link JarReader} and executes a function on the reader. The {@link AgentContainer#getContainerPath()}
+     * is used to locate the jar file.
+     *
+     * @param container The container with a path to a jar file.
+     * @param function  The function to run on the JarReader.
+     * @param <R>       The return type of the function.
+     * @return A new instance of a reader.
+     * @throws IOException If the jar file could not be read.
+     */
+    public static <R> R ofContainer(AgentContainer container, Function<JarReader, R> function) throws IOException {
+        Objects.requireNonNull(container, "Container may not be null");
+        final JarFile jarFile = new JarFile(container.getContainerPath());
+        try (JarReader jarReader = new JarReader(jarFile)) {
+            return function.apply(jarReader);
+        }
+    }
+
+}

--- a/controller/src/main/java/cern/jarrace/controller/rest/controller/AgentContainerController.java
+++ b/controller/src/main/java/cern/jarrace/controller/rest/controller/AgentContainerController.java
@@ -7,6 +7,7 @@ package cern.jarrace.controller.rest.controller;
 
 import cern.jarrace.commons.domain.AgentContainer;
 import cern.jarrace.commons.domain.Service;
+import cern.jarrace.controller.io.JarReader;
 import cern.jarrace.controller.io.JarWriter;
 import cern.jarrace.controller.jvm.AgentRegistrySpawner;
 import cern.jarrace.controller.jvm.AgentRunnerSpawner;
@@ -15,13 +16,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.io.IOException;
+import java.util.*;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 /**
  * {@link RestController} that exposes endpoints to manage {@link AgentContainer}s
@@ -35,6 +37,7 @@ public class AgentContainerController {
     private static final Logger LOGGER = LoggerFactory.getLogger(AgentContainerController.class);
     private static final File DEPLOYMENT_DIR = new File(System.getProperty("java.io.tmpdir"));
     private static final String CONTAINER_NAME_VARIABLE_NAME = "containerName";
+    static final String JAVA_CLASS_SUFFIX = ".java";
 
     @Autowired
     private AgentContainerManager agentContainerManager;
@@ -93,6 +96,33 @@ public class AgentContainerController {
         throw new IllegalArgumentException("Service name must exist");
     }
 
+    @RequestMapping(value = "/{" + CONTAINER_NAME_VARIABLE_NAME + "}/read", method = RequestMethod.GET)
+    public ResponseEntity<String> readSource(@PathVariable(CONTAINER_NAME_VARIABLE_NAME) String containerName,
+                                             @RequestParam("class") String className) {
+        return agentContainerManager.findAgentContainer(containerName)
+                .map(container -> {
+                    try {
+                        return JarReader.ofContainer(container, reader -> {
+                            final String entry = className + JAVA_CLASS_SUFFIX;
+                            try {
+                                return ResponseEntity.ok(reader.readEntry(entry));
+                            } catch (NoSuchElementException e) {
+                                return ResponseEntity.badRequest()
+                                        .body("No class source found for entry " + entry);
+                            } catch (IOException e) {
+                                return ResponseEntity.status(INTERNAL_SERVER_ERROR)
+                                        .body("Failed to read entry " + entry + " inside container " + containerName);
+                            }
+                        });
+                    } catch (IOException e) {
+                        LOGGER.warn("Failed to read from container file {}: " + containerName, e);
+                        return ResponseEntity.status(INTERNAL_SERVER_ERROR)
+                                .body("Failed to open container of name " + containerName);
+                    }
+                })
+                .orElse(ResponseEntity.badRequest().body("No container deployed under the name " + containerName));
+    }
+
     public void setAgentContainerManager(AgentContainerManager agentContainerManager) {
         this.agentContainerManager = agentContainerManager;
     }
@@ -108,4 +138,6 @@ public class AgentContainerController {
     public void setJarWriter(JarWriter jarWriter) {
         this.jarWriter = jarWriter;
     }
+
+
 }

--- a/controller/src/test/java/cern/jarrace/controller/io/JarReaderTest.java
+++ b/controller/src/test/java/cern/jarrace/controller/io/JarReaderTest.java
@@ -1,0 +1,85 @@
+/*
+ * © Copyright 2016 CERN. This software is distributed under the terms of the Apache License Version 2.0, copied
+ * verbatim in the file “COPYING”. In applying this licence, CERN does not waive the privileges and immunities granted
+ * to it by virtue of its status as an Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+package cern.jarrace.controller.io;
+
+import cern.jarrace.commons.domain.AgentContainer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.InvalidPropertyException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.jar.JarFile;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JarReaderTest {
+
+    public static final String JAVA_HOME = System.getProperty("java.home");
+    public static final String MANIFEST_ENTRY = "META-INF/MANIFEST.MF";
+    public static final String RT_PATH = JAVA_HOME + File.separator + "lib" + File.separator + "rt.jar";
+
+    private AgentContainer mockedContainer;
+
+    @Before
+    public void setup() {
+        mockedContainer = mock(AgentContainer.class);
+        when(mockedContainer.getContainerPath()).thenReturn(RT_PATH);
+    }
+
+    @Test
+    public void canCreateReaderFromAgentContainer() throws Exception {
+        assertNotNull(JarReader.ofContainer(mockedContainer, Function.identity()));
+    }
+
+    @Test(expected = IOException.class)
+    public void canFailWhenJarDoesNotExist() throws Exception {
+        File tmpFile = File.createTempFile("test", null);
+        boolean delete = tmpFile.delete();
+        if (!delete) {
+            throw new IllegalStateException("Failed to delete temporary file " + tmpFile);
+        }
+        when(mockedContainer.getContainerPath()).thenReturn(tmpFile.toString());
+        JarReader.ofContainer(mockedContainer, Function.identity());
+    }
+
+    @Test
+    public void canReadEntryInJar() throws IOException {
+        assertNotNull(JarReader.ofContainer(mockedContainer, reader -> {
+            try {
+                return reader.readEntry(MANIFEST_ENTRY);
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void canFailToReadEntryWhenItDoesNotExist() throws IOException {
+        JarReader.ofContainer(mockedContainer, reader -> {
+            try {
+                return reader.readEntry("IDoNotExist");
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
This review is about a small feature added in the controller, where users can get source code from a deployed jar. By sending the url ../container/{name}/read?class={className} the container with 'name' should read a class called 'className' from the jar (stored inside the controller somewhere).
The className variable is meant to be the pure class location (cern.test.Class - without the .java or .class).
